### PR TITLE
Prevent FileNotFoundError During Parallel Inference by Adding Try-Except Block

### DIFF
--- a/run_pretrained_openfold.py
+++ b/run_pretrained_openfold.py
@@ -161,9 +161,12 @@ def generate_feature_dict(
         feature_dict = data_processor.process_multiseq_fasta(
             fasta_path=tmp_fasta_path, super_alignment_dir=alignment_dir,
         )
-
-    # Remove temporary FASTA file
-    os.remove(tmp_fasta_path)
+        
+    # Remove temporary FASTA file    
+    try:
+        os.remove(tmp_fasta_path)
+    except Exception as e:
+        logger.warning(f"Error removing temporary fasta file: {e}, you may be running parallel inference in a shared filesystem")
 
     return feature_dict
 


### PR DESCRIPTION


**Description:**

When running inference in parallel using multiple models that share a common run path, the fasta file may be removed by one process while another is still accessing it. This leads to a `FileNotFoundError`.

To address this issue, this pull request adds a try-except block around the file removal operation. This ensures that if the file has already been removed by another process, the exception is caught gracefully, allowing the inference to continue without interruption.

**Changes:**

- Added a try-except block when attempting to remove the fasta file during inference.


**Testing:**

- Verified that running inference in parallel no longer results in a `FileNotFoundError`.
- Ensured that the try-except block does not interfere with normal file removal when the file exists.